### PR TITLE
Allow RuntimeConfig to be resolved at runtime instead of build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/http",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "description": "An extended module to ohmyfetch",
     "homepage": "https://github.com/nuxt-alt/http",
     "author": "Teranode",

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule({
     defaults: {} as ModuleOptions,
     setup(opts, nuxt) {
         // Combine options with runtime config
-        const moduleOptions: ModuleOptions = defu(nuxt.options.runtimeConfig?.public?.http, opts)
+        const moduleOptions: ModuleOptions = opts
 
         // Default host
         const defaultHost = moduleOptions.host || process.env.NITRO_HOST || process.env.HOST || 'localhost'

--- a/src/runtime/templates/http.plugin.mjs
+++ b/src/runtime/templates/http.plugin.mjs
@@ -1,5 +1,6 @@
 import { createInstance } from '@refactorjs/ofetch'
 import { defineNuxtPlugin } from '#imports'
+import { defu } from "defu";
 
 // Nuxt Options
 const options = JSON.parse('<%= JSON.stringify(options) %>')
@@ -39,23 +40,28 @@ const debugInterceptor = http => {
 '<% } %>'
 
 export default defineNuxtPlugin(ctx => {
+    const runtimeConfig = useRuntimeConfig()
+
+    // Use runtime config to configure options, with module options as the fallback
+    const config = defu({}, runtimeConfig.http, runtimeConfig.public.http, options)
+
     // baseURL
-    const baseURL = process.client ? options.browserBaseURL : options.baseURL
+    const baseURL = process.client ? config.browserBaseURL : config.baseURL
 
     // Defaults
     const defaults = {
         baseURL,
-        retry: options.retry,
-        timeout: process.server ? options.serverTimeout : options.clientTimeout,
-        credentials: options.credentials,
-        headers: options.headers,
+        retry: config.retry,
+        timeout: process.server ? config.serverTimeout : config.clientTimeout,
+        credentials: config.credentials,
+        headers: config.headers,
     }
 
-    if (options.proxyHeaders) {
+    if (config.proxyHeaders) {
         // Proxy SSR request headers
         if (process.server && ctx.ssrContext?.event?.req?.headers) {
             const reqHeaders = { ...ctx.ssrContext.event.req.headers }
-            for (const h of options.proxyHeadersIgnore) {
+            for (const h of config.proxyHeadersIgnore) {
                 delete reqHeaders[h]
             }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ declare module '@nuxt/schema' {
         http?: ModuleOptions
     }
     interface RuntimeConfig {
-        http?: ModuleOptions;
+        http?: Omit<ModuleOptions, 'browserBaseURL'>
     }
     interface PublicRuntimeConfig {
         http?: ModuleOptions


### PR DESCRIPTION
Firstly, thanks for making this repository in the lack of any Nuxt 3 support! Really helped me out :) 

I found that the way the runtime config was passed into the plugin meant that the config was baked in at build time, so could not be overwritten at runtime. This caused me some issues setting the config using environment variables after building a docker image.

I have changed the location of where the runtime config gets passed into the options. Instead of being set in the setup for the module, the runtime config is merged with the options in the plugin. I have tested this and it allows the options to be overwritten at runtime with environment variables.

I've also merged in the private runtime options, which allows the plugin to use server-side-only options when requesting on SSR e.g. an internal API URL. With this, I've excluded the `browserBaseURL` from the private options as it's not applicable in this instance.

With this change, I've bumped the version to 1.6 which I hope you find suitable. 

Please let me know if there's anything you think could be improved in this PR :)  