### PR TITLE
docs: remove `$http.onError` from supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ $http.onRequest(config)
 $http.onResponse(response)
 $http.onRequestError(err)
 $http.onResponseError(err)
-$http.onError(err)
 ```
 
 ## Options


### PR DESCRIPTION
Both https://github.com/refactorjs/ofetch and https://github.com/unjs/ofetch doesn't have `onError` interceptor, as it fires as `onResponseError`. So, I propose to remove `$http.onError` from README. Additionally we can clarify that that 2 interceptors are unified now